### PR TITLE
GHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,68 @@
+name: Dockerize Advent of Code - Leaderboard CI
+
+on:
+  #schedule:
+  #- cron: "0 10 * * *" # everyday at 10am
+  # le ci se lance pour chaque commit (qu'importe la branch ou le tag)
+  push:
+  #cf ci dessous, on ne push pas l'image pour une pull request
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Set current version
+        run: mvn -B versions:set -DnewVersion=${GITHUB_REF##*/} -DprocessAllModules -DgenerateBackupPoms=false
+      - name: Build with Maven
+        run: mvn -B package -DskipTests
+      - name: Upload jar
+        uses: actions/upload-artifact@v2
+        with:
+          name: jar
+          path: ./target/*.jar
+          if-no-files-found: error
+          retention-days: 1
+  docker:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Download jar
+        id: download
+        uses: actions/download-artifact@v2
+        with:
+          name: jar
+          path: ./target
+      - name: Docker meta
+        id: docker_meta
+        uses: crazy-max/ghaction-docker-meta@v1.8.4
+        with:
+          images: inseefrlab/adventofcodeleaderboard # list of Docker images to use as base name for tags
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to DockerHub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          push: ${{ github.event_name != 'pull_request' && github.repository=='InseeFrLab/AdventOfCodeLeaderboard'}}
+          tags: |
+            ${{ steps.docker_meta.outputs.tags }}
+            ${{ github.ref == 'refs/heads/master' && 'inseefrlab/adventofcodeleaderboard:latest' || '' }}
+          labels: ${{ steps.docker_meta.outputs.labels }}
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Login to DockerHub
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' && github.repository=='InseeFrLab/AdventOfCodeLeaderboard'
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}


### PR DESCRIPTION
Pour remplacer gitlab-ci.
Toutes les étapes sont faites pour tous les commits sur toutes les branches.
Ces images ont le tag latest pour les commits sur la branche master, le nom de la branche sinon.
Le push de l'image sur dockerhub ne se fait que sur le repository inseefrlab (pas sur les fork).